### PR TITLE
Mileage code

### DIFF
--- a/mileage/Gemfile
+++ b/mileage/Gemfile
@@ -1,1 +1,3 @@
+source 'https://rubygems.org'
+
 gem 'minitest'

--- a/mileage/Gemfile.lock
+++ b/mileage/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     minitest (5.8.1)
 
@@ -9,4 +10,4 @@ DEPENDENCIES
   minitest
 
 BUNDLED WITH
-   1.10.5
+   1.16.1

--- a/mileage/README.md
+++ b/mileage/README.md
@@ -27,6 +27,11 @@ Then, the Foobarnians would like you to add a couple features:
 
 ##### Also worth thinking about (don't need to actually do it):
 
-Are there any other tests that should be added? Are there other ways the code
-could be improved? How would you advise the Foobarnians on better ways to look at
-this data?
+Are there any other tests that should be added? 
+> Tests for the additional filters would be great. More tests for `Auto` class would be nice.
+
+Are there other ways the code could be improved? 
+> Cleaning up the `mileage.rb` file into a class or module would be desirable.
+
+How would you advise the Foobarnians on better ways to look at this data?
+> Load it into a database and use something like (metabase)[https://metabase.com/]

--- a/mileage/auto.rb
+++ b/mileage/auto.rb
@@ -1,10 +1,11 @@
 class Auto
-  attr_reader :color, :price, :name, :mileage
+  attr_reader :color, :price, :name, :mileage, :fuel
 
   def initialize data
     @color = data[1]
-    @price = data[2] || 0.0
+    @price = data[2].to_f || 0.0
     @mileage = data[3]
     @fuel = data[4]
+    raise ArgumentError, "Missing mileage" if @mileage.nil?
   end
 end

--- a/mileage/auto_seeker.rb
+++ b/mileage/auto_seeker.rb
@@ -6,16 +6,18 @@ class AutoSeeker
     @data = data
   end
 
-  def filter key, match
+  def filter! key, match
     @autos = autos.select do |auto|
-      auto.send(key) == match
+      auto.send(key) == match || 
+      (match.is_a?(Range) && match.include?(auto.send(key)))
     end
   end
 
   def autos
     @autos ||= @data.map do |row|
       Auto.new(row)
-    end
+    rescue ArgumentError
+    end.compact
   end
 
   def self.median_mileage autos

--- a/mileage/auto_seeker_test.rb
+++ b/mileage/auto_seeker_test.rb
@@ -8,6 +8,8 @@ describe AutoSeeker do
       [2,'Blue',13999,25.0,'gas'],
       [3,'Teal',19000,27.0,'gas'],
       [4,'Red',14999,40.0,'diesel'],
+      [5,'Teal',14999,nil,'diesel'],
+      [6,'Teal',14999,32.0,'electric'],
     ]
     @seeker = AutoSeeker.new data
   end
@@ -15,14 +17,19 @@ describe AutoSeeker do
 
   describe "#filter " do
     it "can filter by color " do
-      @seeker.filter 'color', 'Red'
+      @seeker.filter! :color, 'Red'
       @seeker.autos.collect(&:color).uniq.must_equal ['Red']
     end
   end
 
   describe ".median_mileage " do
     it "calculates median mileage for all autos" do
-      AutoSeeker.median_mileage(@seeker.autos).must_equal 26.0
+      AutoSeeker.median_mileage(@seeker.autos).must_equal 27.0
+    end
+
+    it "calculates median mileage for all Teal cars" do
+      @seeker.filter! :color, 'Teal'
+      AutoSeeker.median_mileage(@seeker.autos).must_equal 29.5
     end
   end
 end

--- a/mileage/auto_test.rb
+++ b/mileage/auto_test.rb
@@ -1,0 +1,17 @@
+require "minitest/autorun"
+require "./auto"
+
+describe Auto do
+  describe "#create " do
+    it "creates an Auto if all data present" do
+      car = Auto.new([4,'Red',14999,40.0,'diesel'])
+      car.must_be_instance_of Auto
+    end
+
+    it "throws an exception when missing mileage" do
+      proc { 
+        Auto.new([4,'Red',14999,nil,'diesel']) 
+      }.must_raise ArgumentError
+    end
+  end
+end

--- a/mileage/helpers.rb
+++ b/mileage/helpers.rb
@@ -1,0 +1,14 @@
+module CLI
+  def self.paramaterize(arg)
+    if arg.start_with? '--'
+      filter, value = arg[2..-1].split('=')
+      is_range = value.include? '-'
+      value = is_range ? value.split('-') : value
+      value = is_range ? value.first.to_f..value.last.to_f : value 
+
+      args = [filter.downcase.to_sym, value]
+    else
+      args = [:color, arg]
+    end
+  end
+end

--- a/mileage/mileage.rb
+++ b/mileage/mileage.rb
@@ -1,13 +1,21 @@
 require 'csv'
+require './helpers'
 require './auto_seeker'
 
 data = CSV.read('foobarnian_autos.csv')
 
 seeker = AutoSeeker.new data
-autos = seeker.filter(:color, ARGV[0])
+ARGV.each do |arg|
+  args = CLI.paramaterize(arg)
+  puts "*" * 50
+  puts "Adding filter: #{args.first} should be #{args.last}"
+  puts "*" * 50
+  seeker.filter!(*args)
+end
+autos = seeker.autos
 
 if autos.length == 0
-  abort "no autos with color #{ARGV[0]} found"
+  abort "No autos found"
 end
 
 mileage = AutoSeeker.median_mileage(autos)


### PR DESCRIPTION
This PR addresses the median bug in the `mileage.rb` script. It does so by discarding any `Auto` missing mileage data in the CSV. I chose this approach because I felt that if there is no mileage data, we should not include it in the median calculation.

How I went about it was I made the `Auto` class throw an `ArgumentError` when there was no mileage present. 

This PR also adds new functionality for additional command line filters via flags, namely fuel and price. Here is how it works:

For fuel, you just add a flag `$ ruby mileage.rb Teal --fuel=gas` it works with or without a color as well -  `$ ruby mileage.rb --fuel=gas`.

For price, it's the same but you add a range as the flag value `$ ruby mileage.rb --price=10000-30000.32`.

You can mix and match or use all three `$ ruby mileage.rb Red --price=1000.0-100000.0 --fuel=gas`